### PR TITLE
Update checksum and point to SNAPSHOT instead of latest

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -27,8 +27,8 @@ id = "org.cloudfoundry.stacks.cflinuxfs3"
 id      = "riff-invoker-java"
 name    = "riff Java Invoker"
 version = "0.2.0+snapshot"
-uri     = "https://storage.googleapis.com/projectriff/java-function-invoker/releases/latest/java-function-invoker.jar"
-sha256  = "482f996eb96c3ac7ad9cb5858155900224a0669a09b02a9f013c50565da653ba"
+uri     = "https://storage.googleapis.com/projectriff/java-function-invoker/releases/v0.2.0-SNAPSHOT/java-function-invoker-0.2.0-SNAPSHOT.jar"
+sha256  = "8b27610b1475d64ef6962cd9f510201737c048aca5b314d6f1abf3acb571a592"
 stacks  = [
   "io.buildpacks.stacks.bionic",
   "org.cloudfoundry.stacks.cflinuxfs3",

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -27,7 +27,7 @@ id = "org.cloudfoundry.stacks.cflinuxfs3"
 id      = "riff-invoker-java"
 name    = "riff Java Invoker"
 version = "0.2.0+snapshot"
-uri     = "https://storage.googleapis.com/projectriff/java-function-invoker/releases/v0.2.0-SNAPSHOT/java-function-invoker-0.2.0-SNAPSHOT.jar"
+uri     = "https://storage.googleapis.com/projectriff/java-function-invoker/releases/v0.2.0-SNAPSHOT/snapshots/java-function-invoker-0.2.0-SNAPSHOT-664663e8c4a44e06bde9454e1dab70e6a9884169.jar"
 sha256  = "8b27610b1475d64ef6962cd9f510201737c048aca5b314d6f1abf3acb571a592"
 stacks  = [
   "io.buildpacks.stacks.bionic",


### PR DESCRIPTION
Since the checksum keeps changing, pointing to latest is pointless

The SNAPSHOT includes
https://github.com/projectriff/java-function-invoker/commit/664663e8c4a44e06bde9454e1dab70e6a9884169.