### PR TITLE
Unnecessary Credentials

### DIFF
--- a/.github/workflows/update-draft-release.yml
+++ b/.github/workflows/update-draft-release.yml
@@ -13,12 +13,6 @@ jobs:
               uses: release-drafter/release-drafter@v5
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Docker login gcr.io
-              uses: docker/login-action@v1
-              with:
-                password: ${{ secrets.RIFF_GCLOUD_SERVICE_ACCOUNT_KEY }}
-                registry: gcr.io
-                username: _json_key
             - uses: actions/checkout@v2
             - name: Install yj
               run: |


### PR DESCRIPTION
Previously, the actions logged into Docker with their typical crendentials, even when it wasn't necessary to do so.  This change removes this behavior.